### PR TITLE
Makefile to speed up publishing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,12 @@
-prepare:
-  zip -r Meet_Simultaneous_Interpretation.zip src
+.PHONY: prepare sync_version
+
+APP_VERSION := $(shell cat src/manifest.json | jq -r .version)
+
+prepare: sync_version
+	@echo "Preparing Zip file for Upload"
+	@cd src && zip -qq -r ../Meet_Simultaneous_Interpretation.zip . && cd ../
+	@echo "Zip file created: Meet_Simultaneous_Interpretation.zip"
+
+sync_version:
+	@echo "Syncing Versions: $(APP_VERSION)"
+	@sed -i "" "s/versionNumber\">\(.*\)</versionNumber\">v$(APP_VERSION)</g" src/injection/injected_script.js

--- a/src/injection/injected_script.js
+++ b/src/injection/injected_script.js
@@ -394,7 +394,7 @@ function addControls() {
                         <line stroke-width="50" stroke-linecap="undefined" stroke-linejoin="undefined" id="svg_6" y2="368.48816" x2="699.76505" y1="556.60323" x1="580.33719" fill="none"/>
                       </g>
                     </svg>
-                    <span class="versionNumber">v1.0.5</span>
+                    <span class="versionNumber">v1.0.6</span>
                 </div>
             </div>
     `;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "__MSG_appName__",
     "description": "__MSG_appDesc__",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "manifest_version": 3,
     "default_locale": "en",
     "permissions": [


### PR DESCRIPTION
**Use of a makefile to:**
- Sync the version numbers between `manifest.json` and extension UI
- Create zip file of chrome extension

+ Update version number test included in second commit (using `make prepare`)